### PR TITLE
ci: bump actions/upload-artifact SHA to current v4

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -73,7 +73,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json


### PR DESCRIPTION
Round-2 propagation of the actions/upload-artifact v4 SHA fix. The first sweep was capped by gh-code-search pagination and missed this repo. Tracked in `hyperpolymath/hypatia#213`.