### PR TITLE
fix(ci): hypatia-scan workdir (${{ env.HOME }} resolves empty)

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Build Hypatia scanner (if needed)
-        working-directory: ${{ env.HOME }}/hypatia
+        working-directory: /home/runner/hypatia
         run: |
           if [ ! -f hypatia ] && [ ! -f hypatia-v2 ]; then
             echo "Building hypatia-v2 scanner..."


### PR DESCRIPTION
`hypatia-scan.yml` Build step used `working-directory: \${{ env.HOME }}/hypatia`; `env.HOME` is not a workflow env var so it resolved to `/hypatia` and the job hard-failed. Pinned to `/home/runner/hypatia` (GitHub ubuntu runner HOME). Unblocks the Hypatia Neurosymbolic Analysis check estate-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)