### PR TITLE
WIP: discharge substTop_preserves_typing axiom (Refs #23)

### DIFF
--- a/proofs/BetLang.lean
+++ b/proofs/BetLang.lean
@@ -303,59 +303,65 @@ theorem canonical_dist {v : Expr} {T : Ty} :
     This is one half of type safety. -/
 theorem progress {e : Expr} {T : Ty} (ht : HasType [] e T) :
     IsValue e ∨ ∃ e', Step e e' := by
+  generalize hΓ : ([] : Ctx) = Γ at ht
   induction ht with
   | tInt => left; exact IsValue.litInt
   | tFloat => left; exact IsValue.litFloat
   | tBool => left; exact IsValue.litBool
   | tString => left; exact IsValue.litString
   | tUnit => left; exact IsValue.litUnit
-  | tVar h => simp [Ctx.lookup] at h
+  | tVar hl =>
+    subst hΓ
+    simp [Ctx.lookup] at hl
   | tLam _ _ => left; exact IsValue.lam
-  | @tApp _ e₁ e₂ S T ht1 ht2 ih1 ih2 =>
+  | tApp ht1 _ ih1 ih2 =>
     right
-    rcases ih1 with hv1 | ⟨e₁', hs1⟩
-    · rcases ih2 with hv2 | ⟨e₂', hs2⟩
-      · obtain ⟨body, rfl⟩ := canonical_arrow ht1 hv1
+    rcases ih1 hΓ with hv1 | ⟨_, hs1⟩
+    · rcases ih2 hΓ with hv2 | ⟨_, hs2⟩
+      · subst hΓ
+        obtain ⟨_, rfl⟩ := canonical_arrow ht1 hv1
         exact ⟨_, Step.appLam hv2⟩
       · exact ⟨_, Step.appArg hv1 hs2⟩
     · exact ⟨_, Step.appFun hs1⟩
-  | @tLet _ _ _ S T ht1 ht2 ih1 ih2 =>
+  | tLet _ _ ih1 _ =>
     right
-    rcases ih1 with hv1 | ⟨e₁', hs1⟩
+    rcases ih1 hΓ with hv1 | ⟨_, hs1⟩
     · exact ⟨_, Step.letVal hv1⟩
     · exact ⟨_, Step.letStep hs1⟩
-  | @tIf _ c t e T htc htt hte ihc iht ihe =>
+  | @tIf Γ c t T e htc _ _ ihc _ _ =>
     right
-    rcases ihc with hvc | ⟨c', hsc⟩
-    · obtain ⟨b, rfl⟩ := canonical_bool htc hvc
+    rcases ihc hΓ with hvc | ⟨_, hsc⟩
+    · subst hΓ
+      obtain ⟨b, rfl⟩ := canonical_bool htc hvc
       cases b with
       | true  => exact ⟨t, Step.ifTrue⟩
       | false => exact ⟨e, Step.ifFalse⟩
     · exact ⟨_, Step.ifCond hsc⟩
-  | @tBet _ e₁ e₂ e₃ T ht1 ht2 ht3 ih1 ih2 ih3 =>
+  | tBet _ _ _ ih1 ih2 ih3 =>
     right
-    rcases ih1 with hv1 | ⟨e₁', hs1⟩
-    · rcases ih2 with hv2 | ⟨e₂', hs2⟩
-      · rcases ih3 with hv3 | ⟨e₃', hs3⟩
-        · -- All three are values: bet reduces non-deterministically (pick first)
-          exact ⟨_, Step.betFirst hv1 hv2 hv3⟩
+    rcases ih1 hΓ with hv1 | ⟨_, hs1⟩
+    · rcases ih2 hΓ with hv2 | ⟨_, hs2⟩
+      · rcases ih3 hΓ with hv3 | ⟨_, hs3⟩
+        · exact ⟨_, Step.betFirst hv1 hv2 hv3⟩
         · exact ⟨_, Step.betStep3 hv1 hv2 hs3⟩
       · exact ⟨_, Step.betStep2 hv1 hs2⟩
     · exact ⟨_, Step.betStep1 hs1⟩
-  | @tSample _ e T hte ihe =>
+  | tSample hte ihe =>
     right
-    rcases ihe with hve | ⟨e', hse⟩
-    · obtain ⟨w, rfl, hvw⟩ := canonical_dist hte hve
+    rcases ihe hΓ with hve | ⟨_, hse⟩
+    · subst hΓ
+      obtain ⟨w, rfl, hvw⟩ := canonical_dist hte hve
       exact ⟨w, Step.samplePure hvw⟩
     · exact ⟨_, Step.sampleStep hse⟩
-  | @tDistPure _ e T hte ihe =>
-    rcases ihe with hve | ⟨e', hse⟩
+  | tDistPure _ ihe =>
+    rcases ihe hΓ with hve | ⟨_, hse⟩
     · left; exact IsValue.distPure hve
     · right; exact ⟨_, Step.distPureStep hse⟩
-  | @tDistBind _ e₁ e₂ A B ht1 ht2 ih1 ih2 =>
+  | tDistBind ht1 _ ih1 _ =>
     right
-    rcases ih1 with hv1 | ⟨e₁', hs1⟩
-    · obtain ⟨w, rfl, hvw⟩ := canonical_dist ht1 hv1
+    rcases ih1 hΓ with hv1 | ⟨_, hs1⟩
+    · subst hΓ
+      obtain ⟨_, rfl, hvw⟩ := canonical_dist ht1 hv1
       exact ⟨_, Step.distBindPure hvw⟩
     · exact ⟨_, Step.distBindStep1 hs1⟩
 
@@ -363,43 +369,9 @@ theorem progress {e : Expr} {T : Ty} (ht : HasType [] e T) :
 -- Section 8. Weakening and substitution lemmas
 -- ════════════════════════════════════════════════════════════════════════════
 
-/-- Context extension preserves lookup at positions beyond the insertion point. -/
-theorem lookup_extend_ge {Γ : Ctx} {n : Nat} {U : Ty} (h : n ≥ Γ.length) :
-    Ctx.lookup (Γ ++ [U]) n = if n == Γ.length then some U else none := by
-  induction Γ with
-  | nil =>
-    simp [List.length] at h
-    simp [Ctx.lookup, List.nil_append]
-    omega
-  | cons t Γ' ih =>
-    simp [List.length] at h
-    have hge : n ≥ 1 := by omega
-    match n with
-    | 0 => omega
-    | n' + 1 =>
-      simp [Ctx.lookup, List.cons_append]
-      have : n' ≥ Γ'.length := by omega
-      rw [ih this]
-      simp [List.length]
-      omega
-
-/-- Inserting a type into the context at position `k` preserves typing
-    when variables are shifted accordingly. This is the key structural lemma.
-
-    For the full substitution and preservation proof, we work with a simpler
-    approach: we establish preservation directly by induction on the step
-    relation, using the substitution lemma only for beta-reduction. -/
-
-/-- The substitution lemma: if Γ,x:S ⊢ e : T and Γ ⊢ v : S, then Γ ⊢ e[x↦v] : T.
-
-    We prove a restricted version sufficient for our needs: top-level
-    substitution in a closed context (empty Γ extension). The general version
-    would require a full de Bruijn shifting/substitution calculus; here we
-    state the property axiomatically for the substTop operation and validate
-    it via the specific cases that arise in preservation. -/
-
--- For preservation, we need the substitution property. We prove it by
--- establishing that each specific reduction rule preserves types.
+-- The substitution lemmas live in Section 8.5 below (insertAt-based de Bruijn
+-- weakening + generalised substitution). `substTop_preserves_typing` is the
+-- corollary preservation needs.
 
 -- ════════════════════════════════════════════════════════════════════════════
 -- Section 9. Preservation theorem


### PR DESCRIPTION
**DRAFT** — discharging the `substTop_preserves_typing` axiom (#23).

## What landed (commit 1: `ac6c44d`)

`origin/main` (aa65b23) didn't build. `lean proofs/BetLang.lean` failed with 4 pre-existing errors that blocked any further proof work:

1. **`progress` (L304)** — `induction ht` failed with "index in target's type is not a variable" because `HasType [] e T` has the concrete `[]` index. Refactored with `generalize hΓ : ([] : Ctx) = Γ at ht` + `subst hΓ` in the branches that need the closed-context invariant (`tVar`, `tApp`, `tIf`, `tSample`, `tDistBind`). Used non-`@` patterns where possible; `tIf` still needs `@tIf Γ c t T e ...` because Lean's auto-bound-implicit order is `Γ, c, t, T, e` (T appears in the type of `t`'s premise, so it's bound before `e`).
2. **`lookup_extend_ge` (L367)** — broken `omega` + `rw` chain (IH over wrong index because `induction Γ` didn't generalize `n`). **Deleted** as unused — the substitution machinery to come will use a cleaner `Ctx.insertAt`-based formulation, so this had no caller and won't have one.
3. **Two orphan `/-- ... -/` doc-comments (L386-391, L393-399)** not attached to any declaration. Replaced with a one-line pointer to the upcoming Section 8.5.

`lean proofs/BetLang.lean` now exits 0 with no errors (7 pre-existing unused-variable warnings in `preservation` remain, untouched).

## What's NOT done yet

The actual discharge of `substTop_preserves_typing`. The axiom is still in place at L420. Attempted to write Section 8.5 in this session but hit a budget wall — the proof structure requires careful TAPL Ch. 9-style infrastructure, and several attempts at the foundational `lookup_ctxInsertAt_lt` lemma revealed that the natural statement needs an additional `k ≤ Γ.length` hypothesis (otherwise it's false at empty Γ with k > 0). The deeper friction is `Int.toNat (↑n + amount)` reasoning at the `Expr.var` case of `shift`, especially for `amount = -1` (the shift-down in `substTop` is only sound when no free `var 0` survives — needs an auxiliary tracking lemma).

## Recipe for the next session

1. **`ctxInsertAt`** (non-dot-notation — `Ctx := List Ty` is an `abbrev` so `Γ.insertAt` resolves to `List.insertAt` which doesn't exist): `def ctxInsertAt (Γ : Ctx) (k : Nat) (U : Ty) : Ctx := Γ.take k ++ U :: Γ.drop k`.
2. **Three lookup lemmas, all needing `k ≤ Γ.length`**:
   - `lookup_ctxInsertAt_lt: n < k → Ctx.lookup (ctxInsertAt Γ k U) n = Ctx.lookup Γ n`
   - `lookup_ctxInsertAt_eq: Ctx.lookup (ctxInsertAt Γ k U) k = some U`
   - `lookup_ctxInsertAt_gt: n > k → Ctx.lookup (ctxInsertAt Γ k U) n = Ctx.lookup Γ (n - 1)`
3. **`shift_preserves_typing`** (weakening, `amount = 1` only): `HasType Γ e T → ∀ k U, k ≤ Γ.length → HasType (ctxInsertAt Γ k U) (shift 1 k e) T`. Induction on `HasType`; binder cases (`tLam`, `tLet`) bump `k` by 1 and recurse. Variable case needs `Int.toNat (↑n + 1) = n + 1`.
4. **`subst_preserves_typing`** (generalised): `HasType (ctxInsertAt Γ k S) e T → HasType Γ v S → HasType (ctxInsertAt Γ k S) (subst k (shift (k+1 : Int) 0 v) e) T`. Induction on `e`. Binder cases recurse with `k+1` after pulling in the extra `shift 1 0`.
5. **"No surviving var k" tracking lemma**: after `subst k v e`, define a predicate `freeVarNotIn k e` and prove it holds. Then prove `shift_down` preserves typing when this predicate holds.
6. **Headline**: `substTop_preserves_typing Γ S T body v hb hv := ...` combining the chain. Then delete `axiom substTop_preserves_typing` at L420 (was 420, may be a few lines off after commit 1). Verify `preservation` still typechecks.

Estimated ~300-400 LoC remaining. Standard TAPL Ch. 9 mechanisation, but the `Int.toNat` clamping in BetLang's `shift` (signed amount) adds non-trivial arithmetic friction at every `var` case.

Closes #23 once the discharge is complete and the axiom is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)