### PR TITLE
fix(ci): repin hypatia-scan to standards main SHA (was orphan squash-source)

### DIFF
--- a/.github/workflows/hypatia-scan.yml
+++ b/.github/workflows/hypatia-scan.yml
@@ -25,5 +25,5 @@ permissions:
 
 jobs:
   hypatia:
-    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@97df762107501909f50bb770e9bc200b6c415600
+    uses: hyperpolymath/standards/.github/workflows/hypatia-scan-reusable.yml@915139d73560e65a8240b8fc7768698658502c89
     secrets: inherit


### PR DESCRIPTION
## Summary

`.github/workflows/hypatia-scan.yml` pinned `uses:` to SHA `97df762...`, which is the **original branch-tip commit** from standards#193 (`feat/hypatia-scan-reusable`). That PR was **squash-merged**, producing a new commit `915139d...` on `standards/main`. The original SHA was orphaned and is not reachable from `standards/main`.

GitHub Actions cannot resolve `uses:` against an orphan SHA, so every hypatia-scan run on this repo failed with **"This run likely failed because of a workflow file issue"** before any job started. That left the required `Hypatia Neurosymbolic Analysis` check unreported on every PR, blocking auto-merge across the board.

## Fix

Repin to `915139d73560e65a8240b8fc7768698658502c89` — the actual `hypatia-scan-reusable.yml` commit on `standards/main`.

## Estate-wide context

This is the betlang-local instance of the orphan-SHA pattern audited in [standards#220](https://github.com/hyperpolymath/standards/pull/220). Other repos that adopted the hypatia-scan wrapper likely have the same bug — sweep is owed.

## Chicken-and-egg note

This PR's own CI run will face the same orphan-SHA blocker, because the fix only takes effect once it's on `main`. Owner may need to admin-merge this single PR to break the cycle. Subsequent PRs will see the working pin.

After this lands, a follow-up branch-protection update should change required check from `Hypatia Neurosymbolic Analysis` to `hypatia / Hypatia Neurosymbolic Analysis` (the workflow-prefixed name the reusable actually produces — same rename already applied to ephapax this session).

## Test plan

- [x] Single-line SHA bump in a workflow file
- [x] GPG-signed commit (key `4A03639C…2867091E`, noreply email)
- [x] Auto-merge SQUASH enabled (will not fire until the chicken-and-egg is broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)