### PR TITLE
fix(ci): repin setup-racket to actual v1.15 SHA (was orphan)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Racket
-        uses: Bogdanp/setup-racket@67838a16f2122684177c86729eb9cf0438ec677b # v1.15
+        uses: Bogdanp/setup-racket@2466913449df77df2bad149d1f2fc4e1ea4795dd # v1.15
         with:
           version: ${{ matrix.racket-version }}
           packages: 'rackunit'
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Racket
-        uses: Bogdanp/setup-racket@67838a16f2122684177c86729eb9cf0438ec677b # v1.15
+        uses: Bogdanp/setup-racket@2466913449df77df2bad149d1f2fc4e1ea4795dd # v1.15
         with:
           version: 'current'
 


### PR DESCRIPTION
## Summary

\`.github/workflows/test.yml\` pinned \`Bogdanp/setup-racket@67838a16…\` — a SHA that **no longer exists** in the upstream repo (\`HTTP 422 No commit found\`). Every Racket Test job (8.11, 8.12, current) failed with:

\`\`\`
Unable to resolve action 'Bogdanp/setup-racket@67838a16f2122684177c86729eb9cf0438ec677b',
unable to find version '67838a16f2122684177c86729eb9cf0438ec677b'
\`\`\`

before any test could run. This is the root cause of the Racket Test failures blocking every betlang PR.

## Fix

Repin to \`2466913449df77df2bad149d1f2fc4e1ea4795dd\` — the actual SHA for the \`v1.15\` tag, verified via \`gh api repos/Bogdanp/setup-racket/git/ref/tags/v1.15\`. The \`# v1.15\` comment is preserved as the human-readable tag pointer.

## Estate context

This is the **second orphan-SHA pin** found in this repo today. The first was the hypatia-scan-reusable pin fixed in [#42](https://github.com/hyperpolymath/betlang/pull/42). Sibling pattern to the estate-wide audit in [standards#220](https://github.com/hyperpolymath/standards/pull/220) — the orphan-SHA campaign should sweep external action pins too, not just internal reusable workflow pins.

## After this lands

Racket tests will actually run. They may or may not pass — but at least they will execute rather than failing at setup. If tests pass, this clears one of the three blockers on the other betlang PRs (the others are TypeScript allowlist coverage and governance/Workflow-security-linter).

## Test plan

- [x] Two-line SHA bump in a workflow file
- [x] GPG-signed commit (key 4A03639C…2867091E, noreply email)
- [x] Auto-merge SQUASH enabled (will land when CI green — including the hypatia workflow that #42 just fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)