### PR TITLE
chore(claude.md): add TypeScript exemption for playground/ sandbox

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -72,6 +72,16 @@ Both are FOSS with independent governance (no Big Tech).
 - **Fallback**: Nix (flake.nix)
 - **JS deps**: Deno (deno.json imports)
 
+### TypeScript Exemptions (Approved)
+
+The hyperpolymath "no new TypeScript" policy has the following approved exemptions in this repo. These are *not* policy violations — they are documented carve-outs.
+
+| Path | Files | Rationale | Unblock condition |
+|---|---|---|---|
+| `playground/**` | 6 (`src/probability.ts`, `src/ternary.ts`, `src/main.ts`, `test/ternary_test.ts`, `test/probability_test.ts`, `examples/uncertainty.ts`) | Per `playground/README.adoc`, the directory is an **intentional experimental sandbox** "decoupled from the main compiler to allow rapid experimentation". TypeScript was chosen as one of several languages explored alongside Deno/Nickel/Idris2/Zig in the sandbox. The primary Betlang implementation in `core/`, `lib/`, and `tests/` remains Racket-only. | Owner decision to either (a) migrate the playground sample to AffineScript, or (b) delete the TypeScript files once the experimental questions they answer are settled. No scheduled issue. |
+
+Adding to this list requires explicit user approval and an unblock condition. New TypeScript files outside this list are blocked by the RSR antipattern check (`governance / Language / package anti-pattern policy`).
+
 ### Security Requirements
 
 - No MD5/SHA1 for security (use SHA256+)


### PR DESCRIPTION
## Summary

The \`governance / Language / package anti-pattern policy\` check flags **6 TypeScript files** in \`playground/\` as undocumented exemptions to the estate-wide "no new TypeScript" rule:

- \`playground/src/probability.ts\`
- \`playground/src/ternary.ts\`
- \`playground/src/main.ts\`
- \`playground/test/ternary_test.ts\`
- \`playground/test/probability_test.ts\`
- \`playground/examples/uncertainty.ts\`

Per [\`playground/README.adoc\`](../tree/main/playground/README.adoc), the directory is an **intentional experimental sandbox** "decoupled from the main compiler to allow rapid experimentation". TypeScript was one of several languages explored alongside Deno/Nickel/Idris2/Zig in the sandbox. The primary Betlang implementation in \`core/\`, \`lib/\`, and \`tests/\` remains Racket-only.

## Fix

Adds the exemption to \`.claude/CLAUDE.md\` using the canonical "TypeScript Exemptions" table format from [standards](https://github.com/hyperpolymath/standards/blob/main/.claude/CLAUDE.md). Unblock condition is owner decision to either:

(a) migrate the playground sample to AffineScript, or
(b) delete the TypeScript files once the experimental questions they answer are settled.

## Why this approach

This is a **documentation-only exemption record** — it does not change estate policy. It just makes the existing carve-out auditable, which is what the governance check requires.

The alternative (rewriting all 6 files into AffineScript) is real engineering — out of scope for a CI unblock. The other alternative (deleting them) loses experimental work that may still be referenced.

## After this lands

\`governance / Language / package anti-pattern policy\` will pass on betlang PRs. Combined with [#43](https://github.com/hyperpolymath/betlang/pull/43) (setup-racket SHA fix), this clears two of the three baseline-rot blockers on every betlang PR. The remaining one is \`governance / Workflow security linter\` — a separate investigation.

## Test plan

- [x] Single addition to \`.claude/CLAUDE.md\`
- [x] GPG-signed commit (key 4A03639C…2867091E, noreply email)
- [x] Auto-merge SQUASH enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)