### PR TITLE
fix(ci): add SPDX header + permissions to comprehensive-quality.yml

### DIFF
--- a/.github/workflows/comprehensive-quality.yml
+++ b/.github/workflows/comprehensive-quality.yml
@@ -1,4 +1,7 @@
+# SPDX-License-Identifier: MPL-2.0
+# SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
 name: Comprehensive Quality Gates
+permissions: read-all
 on:
   push:
     branches: [main, master]


### PR DESCRIPTION
## Summary

\`governance / Workflow security linter\` fails on every betlang PR with:

\`\`\`
ERROR: .github/workflows/comprehensive-quality.yml missing SPDX header
ERROR: .github/workflows/comprehensive-quality.yml missing top-level 'permissions:' declaration
\`\`\`

## Fix

Two-line SPDX header at the top of the file + a top-level \`permissions: read-all\` declaration. Matches the shape used by the other workflow files in this repo (see \`test.yml\` lines 1-3).

\`read-all\` is the safe minimum — individual jobs can override with more restrictive permissions if they need write access. No job in this file currently writes to the repo, so \`read-all\` is sufficient.

## Why this matters

Combined with the three sibling baseline-rot fixes filed today:

- [#42](https://github.com/hyperpolymath/betlang/pull/42) — hypatia-scan orphan SHA pin
- [#43](https://github.com/hyperpolymath/betlang/pull/43) — setup-racket orphan SHA pin
- [#44](https://github.com/hyperpolymath/betlang/pull/44) — TypeScript playground exemption
- **this PR** — comprehensive-quality security hardening

…this clears the **last of the baseline-rot blockers** on every betlang PR. After all four land, every existing MERGEABLE betlang PR should be able to auto-merge through normal CI channels.

## Test plan

- [x] Three-line addition to a workflow file (SPDX × 2 + permissions × 1)
- [x] GPG-signed commit (key 4A03639C…2867091E, noreply email)
- [x] Auto-merge SQUASH enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)