### PR TITLE
chore(estate): betlang reconciliation + 6a2 currency + license branding

### DIFF
--- a/.machine_readable/6a2/ECOSYSTEM.a2ml
+++ b/.machine_readable/6a2/ECOSYSTEM.a2ml
@@ -4,13 +4,13 @@
 # ECOSYSTEM.a2ml — Betlang ecosystem position
 [metadata]
 version = "1.1"
-last-updated = "2026-06-02"
+last-updated = "2026-06-13"
 
 [project]
 name = "Betlang"
 purpose = "Ternary probabilistic programming with Dutch book prevention and gambling harm reduction"
 role = "programming-language"
-license = "PMPL-1.0 (SPDX: MPL-2.0)"
+license = "Palimpsest License (SPDX: MPL-2.0)"
 repo = "https://github.com/hyperpolymath/betlang"
 
 [position-in-ecosystem]
@@ -54,7 +54,7 @@ role = "AffineScript tooling"
 [[related-projects.tooling]]
 name = "palimpsest-license"
 repo = "https://github.com/hyperpolymath/palimpsest-license"
-role = "PMPL-1.0 license definition (betlang uses PMPL-1.0 / SPDX: MPL-2.0)"
+role = "Palimpsest License definition (betlang uses Palimpsest License / SPDX: MPL-2.0)"
 
 [external-dependencies]
 proof-verifier = "Lean 4 (leanprover/lean4:v4.15.0)"

--- a/.machine_readable/6a2/META.a2ml
+++ b/.machine_readable/6a2/META.a2ml
@@ -7,7 +7,7 @@ version = "1.1"
 last-updated = "2026-06-02"
 
 [project-info]
-license = "PMPL-1.0 (SPDX: MPL-2.0)"
+license = "Palimpsest License (SPDX: MPL-2.0)"
 author = "Jonathan D.A. Jewell (hyperpolymath)"
 contact = "j.d.a.jewell@open.ac.uk"
 

--- a/.machine_readable/6a2/STATE.a2ml
+++ b/.machine_readable/6a2/STATE.a2ml
@@ -5,9 +5,9 @@
 [metadata]
 project = "betlang"
 version = "0.8.0-dev"
-last-updated = "2026-06-02"
+last-updated = "2026-06-13"
 status = "active"
-session = "affinescript-alignment + governance + echo-types — 2026-06-02"
+session = "echo operations (functor/comonad surface) + estate reconciliation — 2026-06-13"
 
 [project-context]
 name = "Betlang"
@@ -16,7 +16,7 @@ Safe probabilistic programming with Dutch book prevention and gambling harm redu
 Core primitive: (bet A B C) — ternary stochastic choice. Type system adds Echo T / EchoR T
 structured-loss formers (proof-relevant, ghost-erased). Proofs machine-checked in Lean 4.
 """
-completion-percentage = 87
+completion-percentage = 88
 
 [position]
 phase = "proof-foundation + governance-alignment + echo-types-integration"
@@ -28,6 +28,12 @@ maturity = "experimental"  # experimental | alpha | beta | production | lts
 # PR #54: Governance/CI debt — Cargo.toml license, rackunit conflict, timeout-minutes,
 #          .governance-allowlist, .hypatia-ignore, delete Java, ReScript → AffineScript
 # PR #55: Echo T / EchoR T type formers in Rust checker + Lean + spec + docs
+# PR #56: Echo operations typed — echo / echo_output / echo_map / echo_duplicate /
+#          echo_to_residue / sample_echo (functor + comonad surface; type-level/ghost).
+#          38 bet-check tests pass; proof-scan clean. README/docs/PROOF tracking updated.
+# Session 2026-06-13: estate reconciliation — synced local to main; identified
+#          estate-standardization-20260607 as FULLY MERGED into main (safe to delete;
+#          deletion blocked by git proxy HTTP 403 → owner UI action). Metadata currency.
 
 [route-to-mvp]
 milestones = [
@@ -35,27 +41,29 @@ milestones = [
   "M2: Governance clean — licence, language policy, Racket tests, timeout [DONE #54]",
   "M3: Echo types core — Type::Echo/EchoR, unify, lower, Lean Ty.echo/echoR [DONE #55]",
   "M4: Discharge substTop_preserves_typing axiom (PROOF-STATUS TP-4) [DONE — now a proved theorem; axiom-free core]",
-  "M5: Echo operations — echo_intro, proj1, echo_to_residue; typing rules",
-  "M6: sample_echo / bet_echo probabilistic bridge",
+  "M5: Echo operations — echo/echo_output/echo_map/echo_duplicate/echo_to_residue typing rules [DONE #56, type-level]",
+  "M6: sample_echo probabilistic bridge [DONE #56, type-level]; bet_echo runtime retention [deferred]",
   "M7: Julia backend Phase 2 — core language features",
 ]
 
 [proof-obligations]
-# See PROOF-STATUS.md for the full register (13 obligations)
+# See PROOF-STATUS.md for the full register
 proved = ["TP-1 Progress", "TP-2 Preservation", "TP-3 Monad laws", "TP-4 substTop_preserves_typing (discharged — axiom-free)"]
 axioms = []
-remaining = 9
+remaining = 10  # incl. new TP-5 (echo-operation metatheory in Lean — mirrors #56's typed surface)
 
 [blockers-and-issues]
 issues = [
-  "bet-wasm E0308: pre-existing WASM backend breakage (match arm type mismatch, not caused by any of #53-55)",
-  "Echo operations deferred: no echo_intro/proj1/echo_to_residue until runtime/proof story settled",
+  "bet-wasm E0308: pre-existing WASM backend breakage (match arm type mismatch, not caused by any of #53-56)",
+  "Echo operations typed at type-level (#56: functor/comonad surface); runtime residue payload + bet_echo retention still deferred; Lean metatheory is TP-5",
+  "estate-standardization-20260607 branch fully merged into main; deletion blocked by git proxy (403) — owner UI action",
 ]
 
 [critical-next-actions]
 actions = [
-  "TP-5: Echo-operation typing rules + metatheory in Lean (echo_intro, echo_to_residue, proj1)",
-  "sample_echo / bet_echo probabilistic bridge (Dist T → Echo T)",
+  "Harden bet-check: occurs check in unify() + real type schemes (replace shared-var pseudo-polymorphism)",
+  "TP-5: mirror #56's echo-operation typing rules in Lean + re-establish Progress/Preservation",
+  "bet_echo runtime branch-tag retention (Dist/bet collapse → Echo residue payload)",
   "Julia backend Phase 2 — core language features",
   "bet-wasm E0308: fix pre-existing WASM backend match-arm type mismatch",
 ]
@@ -71,9 +79,9 @@ config = "Nickel / 6a2 Scheme (.a2ml)"
 banned = ["TypeScript (except playground sandbox)", "Node.js", "npm", "Go", "Python", "Java", "Kotlin", "Swift"]
 
 [maintenance-status]
-last-run-utc = "2026-06-02T14:00:00Z"
+last-run-utc = "2026-06-13T00:00:00Z"
 last-result = "pass"  # unknown | pass | warn | fail
 # Racket tests: pass (current + 8.11 + 8.12 on PR #54)
 # Governance: pass (all checks on PR #54)
 # Lean proofs: pass (proofs.yml lake build on PR #53)
-# Echo types: pass (cargo test -p bet-check: 27 tests pass on PR #55)
+# Echo types: pass (cargo test -p bet-check: 38 tests pass on PR #56 — 27 base + echo operations)

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,42 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# Architecture
+
+BetLang is a **multi-layer system** with clearly separated responsibilities. Each layer
+has a single job, and the boundaries are deliberate.
+
+| Layer | Language | Responsibility | Authority |
+|-------|----------|----------------|-----------|
+| **Frontend / spec** | Racket | `#lang betlang`; `syntax-parse` + nanopass IR; lazy ternary semantics | **Source of truth for semantics** |
+| **Compute kernel** | Julia | High-performance numerical/statistical execution (Distributions.jl, StatsBase.jl, Random.jl); the uncertainty number tower migrates here | Performance path |
+| **Proof / verification** | Lean 4 | Machine-checks Progress, Preservation, distribution monad laws; `lakefile.lean` + `proofs.yml` | Trust |
+| **Compiler tooling** | Rust | `bet-core` (types incl. `Echo`/`EchoR`), `bet-check` (HM checker + unifier), `bet-parse` (LALRPOP), `bet-wasm` (paused) | Tooling only — **not** semantics |
+
+## Why separate them
+
+- **Racket is canonical** because the lazy ternary semantics (`(bet A B C)` evaluates
+  only the chosen branch) are subtle and must have one unambiguous definition. The Rust
+  checker and Lean proofs *model* that semantics; they do not redefine it.
+- **Julia is the kernel** because the numeric/statistical workloads (sampling, inference,
+  the number tower) want a mature scientific stack. BetLang drives Julia; it does not
+  reimplement it. See [Formal Verification](Formal-Verification) for how this complements
+  rather than competes with the scientific-computing incumbents.
+- **Lean is firewalled** so the trusted base stays small and auditable
+  (`docs/proof-debt.adoc`): zero `sorry`, axiom-free core.
+- **Rust is tooling** (type-check, parse, future WASM) — convenient and fast, but
+  explicitly *not* authoritative. The workspace `Cargo.toml` says as much at the top.
+
+## Repository layout (orienting)
+
+```
+core/            Racket frontend — canonical semantics
+lib/             Racket libraries (distributions, sampling, markov, risk, …)
+compiler/        Rust tooling — bet-core / bet-check / bet-parse / bet-eval / bet-codegen / bet-wasm
+proofs/          Lean 4 — BetLang.lean + theorems/ + papers/
+verification/    RSR verification posture (coverage, safety_case, traceability)
+docs/            Design docs (echo-types.adoc, number-tower, semantics, comparison)
+.machine_readable/  6a2 state/meta + contractiles + self-validating (k9) + svc
+```
+
+See [Type System](Type-System) and [Echo Types](Echo-Types) for the `bet-check` layer in
+depth, and [Roadmap](Roadmap) for what each layer still owes.

--- a/wiki/Echo-Types.md
+++ b/wiki/Echo-Types.md
@@ -1,0 +1,81 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# Echo Types — Structured Loss as a Typed Object
+
+When a computation collapses information — a `(bet A B C)` picks one branch, a `sample`
+marginalises away which draw fired — the *fact of what was lost* normally vanishes.
+**Echo types** make that residue a first-class, typed object.
+
+## The idea (and where it comes from)
+
+Upstream, in the Agda repo [`echo-types`](https://github.com/hyperpolymath/echo-types)
+(the **source of truth**), the echo at `y : B` for a map `f : A → B` is the fibre
+
+```
+Echo f y  :=  Σ (x : A), (f x ≡ y)
+```
+
+— a *proof-relevant* record of which inputs collapsed onto `y`. BetLang is
+**non-dependent**, so it does not represent the literal fibre. Instead it adds two
+**unary type formers**:
+
+| Former | Meaning |
+|--------|---------|
+| `Echo T`  | A `T`-value carrying a proof-relevant residue of retained loss. **Distinct from `T`.** |
+| `EchoR T` | The strict, non-recoverable residue of `Echo T`. |
+
+The load-bearing invariant: **`Echo T` is not `T`.** `unify(Echo T, T)` fails *by design*
+(and so does `unify(Echo T, EchoR T)`). There is **no implicit forgetting** `Echo T → T`;
+you must ask for the value back explicitly. If `Echo T` unified with `T`, the checker
+would lose the entire point of retained loss.
+
+## Operations (the functor + comonad surface)
+
+`bet-check` makes the formers *operational* via polymorphic builtins (each instantiated
+with a fresh carrier per use site, so they are genuinely generic). Surface syntax is
+ordinary application — `echo(x)` — so no grammar change was needed.
+
+| Operation | Typing rule | Role |
+|-----------|-------------|------|
+| `echo`            | `'a → Echo 'a`              | introduction (`echo-intro`) |
+| `echo_output`     | `Echo 'a → 'a`              | **explicit** projection — the comonad **counit** |
+| `echo_map`        | `('a → 'b) → Echo 'a → Echo 'b` | functor action (`map-over`) |
+| `echo_duplicate`  | `Echo 'a → Echo (Echo 'a)`  | comonad comultiplication |
+| `echo_to_residue` | `Echo 'a → EchoR 'a`        | lower a full echo to its strict residue |
+| `sample_echo`     | `Dist 'a → Echo 'a`         | probabilistic-support bridge — retains what `sample` discards |
+
+Together `echo_map` / `echo_output` / `echo_duplicate` give `Echo` the **functor +
+comonad** structure. This is the *ungraded, ghost shadow* of the **graded comonad of
+structured loss** proved upstream (`EchoGradedComonad.agda`: `gextract` / `gduplicate` /
+coassoc). BetLang carries the *typing*; the *laws* live in the Agda (and are tracked for
+Lean as obligation **TP-5**).
+
+## Ghost / erased
+
+`Echo T` and `EchoR T` **erase to `T` at runtime** — no residue payload is materialised
+yet. The value today is the *typed discipline* (you cannot accidentally forget; forgetting
+is explicit and visible in types), plus the cross-repo anchoring to machine-checked
+semantics. A future pass may give the residue a runtime representation (branch tags,
+support traces); until then BetLang deliberately avoids premature commitment.
+
+## The `bet` bridge
+
+The core primitive bridges to `Echo` *by composition*, with no new machinery:
+`echo(bet a b c) : Echo T` already type-checks — viewing the branch-collapse as a
+retained-loss site. A dedicated `bet_echo` is only needed for **runtime** branch-tag
+retention (deferred).
+
+## Why this matters
+
+`Echo` turns "irreversible computation" into "reversible *representation*": the collapse
+still happens, but the type remembers that it happened and refuses to silently pretend it
+didn't. That is the seed of provenance, auditability, and differential/▢-style reasoning
+in a probabilistic setting — see [Formal Verification](Formal-Verification) for how this
+slots into BetLang's proof story and how it sets BetLang apart from untyped numeric tools.
+
+## Source
+
+- `compiler/bet-core/src/types.rs` — `Type::Echo`, `Type::EchoR`
+- `compiler/bet-check/src/lib.rs` — `echo_builtin_type`, unification distinctness, tests
+- `docs/echo-types.adoc` — full design rationale
+- `proofs/BetLang.lean` — `Ty.echo` / `Ty.echoR` (formers; operations' metatheory is TP-5)

--- a/wiki/Formal-Verification.md
+++ b/wiki/Formal-Verification.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# Formal Verification — and How BetLang Compares
+
+BetLang's claim is not "a faster numeric kernel" — Julia, R, Octave, Scilab, Mathematica
+and Maple are all formidable there. Its claim is **typed, proof-anchored uncertainty**:
+the language's loss/uncertainty objects are *checked by a type system* and *grounded in
+machine-checked metatheory*. This page covers both halves.
+
+## The Lean 4 layer
+
+The core calculus is mechanised in `proofs/BetLang.lean` as a first-class Lake project
+(CI-verified by `.github/workflows/proofs.yml`):
+
+| ID | Theorem | Status |
+|----|---------|--------|
+| TP-1 | **Progress** — a well-typed closed term is a value or steps | ✅ proved |
+| TP-2 | **Preservation** — typing is preserved under reduction | ✅ proved |
+| TP-3 | **Distribution monad laws** (left id, right id, assoc) | ✅ proved |
+| TP-4 | Discharge the `substTop_preserves_typing` axiom | ✅ proved — **axiom-free core** |
+| TP-5 | Echo-operation typing rules + metatheory (mirror `bet-check`) | ⏳ open |
+
+**Zero `sorry`.** After TP-4 the only axiom dependencies are Lean 4 core
+(`propext`, `Classical.choice`, `Quot.sound`). The trusted-base ledger lives in
+`docs/proof-debt.adoc`; obligations are enumerated in `PROOF-NEEDS.md` and tracked in
+`PROOF-STATUS.md`. A banned-pattern gate (`tools/proof-scan.sh`) forbids
+`sorry`/`admit`/`postulate`/`believe_me`/`unsafeCoerce` in CI.
+
+The Echo formers currently appear in Lean as *type formers only* (`Ty.echo`, `Ty.echoR`),
+so Progress/Preservation are unaffected; mirroring the operational typing rules from
+`bet-check` is the open obligation **TP-5**.
+
+## How BetLang compares to the scientific/CAS languages
+
+BetLang complements rather than competes with these tools — and the differentiator is the
+type/proof layer, not raw numerics.
+
+| System | Uncertainty model | Typed loss/uncertainty? | Machine-checked metatheory? | Relationship to BetLang |
+|--------|-------------------|--------------------------|------------------------------|--------------------------|
+| **Julia** | Distributions.jl, rich numerics | No (dynamic types) | No (the *companion* `EchoTypes.jl` is the executable echo shadow) | **Compute kernel** — BetLang's high-performance backend; `StatistEase` cross-checks |
+| **R** | distributions, sampling | No | No | Statistics interchange; BetLang adds typed support-retention |
+| **Octave / Scilab** | numeric matrices, Monte Carlo | No | No | Numeric kernels; no notion of typed information-loss |
+| **Mathematica** | symbolic + probability | No (symbolic, untyped) | No | Symbolic CAS peer; BetLang is symbolic-*and*-typed-*and*-proved |
+| **Maple** | symbolic + statistics | No | No | As Mathematica |
+
+The recurring column is the point: **none of R/Octave/Scilab/Mathematica/Maple gives
+uncertainty or information-loss a *type*, and none ships a machine-checked metatheory.**
+BetLang does both:
+
+- **Typed uncertainty** — the [Number Tower](Number-Tower) (14 systems: Gaussian, interval,
+  fuzzy, Bayesian, VaR/CVaR, surreal, p-adic, imprecise, Dempster–Shafer, …) *is* the type
+  system, and [Echo types](Echo-Types) type the *loss* itself.
+- **Proof-anchored** — the Lean 4 metatheory above, plus the Echo formers' meaning being
+  inherited from the machine-checked Agda [`echo-types`](https://github.com/hyperpolymath/echo-types).
+
+So the honest framing: **Julia is where BetLang computes; the Agda `echo-types` spine is
+where BetLang's loss types get their meaning; Lean is where BetLang's calculus is proved
+sound.** R/Octave/Scilab/Mathematica/Maple are the numeric/symbolic incumbents BetLang
+positions against by adding the typed, proof-backed layer they lack.
+
+## See also
+
+- [Echo Types](Echo-Types) — the structured-loss formers and operations
+- [Type System](Type-System) — the Hindley–Milner core that hosts them
+- `docs/proof-debt.adoc`, `PROOF-STATUS.md` — the trusted-base ledger

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,46 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# BetLang Wiki
+
+**BetLang** is a *Symbolic Probabilistic Metalanguage* — a **probabilistic computer
+algebra system (CAS)**, not a betting language. Its one idea:
+
+> Computation is structured choice under uncertainty.
+
+The fundamental primitive is the ternary form `(bet A B C)` — a probabilistic, **lazy**
+choice between three branches (only the selected branch is evaluated). On top of that
+sit two things that distinguish BetLang from every mainstream numeric/CAS tool: a
+**type system that treats uncertainty and information-loss as first-class typed objects**
+(the uncertainty number tower + **Echo types**), and a **machine-checked metatheory**
+(Lean 4).
+
+## Map of this wiki
+
+| Page | What it covers |
+|------|----------------|
+| [Architecture](Architecture) | The four-layer system: Racket (authoritative semantics) · Julia (compute kernel) · Lean 4 (proofs) · Rust (compiler tooling) |
+| [The `bet` Primitive & Ternary Semantics](Ternary-Semantics) | `bet` / `bet/weighted` / `bet/conditional` / `bet/lazy`; Kleene ternary logic vs ternary probabilistic belief |
+| [Type System](Type-System) | Hindley–Milner core in `bet-check`; the Echo/`EchoR` structured-loss formers and their operations |
+| [Echo Types](Echo-Types) | Structured loss as a typed object; the functor/comonad surface; the cross-repo Agda proof anchor |
+| [Formal Verification](Formal-Verification) | Lean 4 Progress / Preservation / monad laws; the proof-debt ledger; **how BetLang compares to Julia, R, Octave, Mathematica, Maple, Scilab** |
+| [Uncertainty Number Tower](Number-Tower) | The 14 uncertainty-aware number systems (Gaussian, interval, fuzzy, Bayesian, p-adic, Dempster–Shafer, …) |
+| [Roadmap](Roadmap) | Milestones M1–M7, open proof obligations, next advances |
+
+## Status (2026-06-13)
+
+| Layer | State |
+|-------|-------|
+| Racket frontend | ✅ Authoritative semantics |
+| Lean 4 proofs | ✅ Progress + Preservation + monad laws; **axiom-free core** (TP-4 discharged) |
+| Rust type-checker (`bet-check`) | ✅ HM + Echo formers **+ typed echo operations** (functor/comonad surface) |
+| Julia compute backend | 🟡 Active development |
+| `bet-wasm` backend | ⏸️ Paused (pre-existing build issue) |
+
+## Ecosystem position
+
+BetLang is the **applied probabilistic consumer** in a three-repo Echo-types spine:
+- [`echo-types`](https://github.com/hyperpolymath/echo-types) — Agda, the **source of truth** (constructive, `--safe --without-K`).
+- [`EchoTypes.jl`](https://github.com/hyperpolymath/EchoTypes.jl) — Julia, the **executable finite-domain shadow**.
+- **BetLang** — borrows the unary `Echo T` / `EchoR T` formers as a *typed discipline* over probabilistic loss.
+
+License: **Palimpsest License (SPDX: MPL-2.0)**.

--- a/wiki/Number-Tower.md
+++ b/wiki/Number-Tower.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# The Uncertainty Number Tower
+
+BetLang's "real moat" is that **uncertainty is not noise to be averaged away — it is a
+first-class, typed object.** The language ships (target: 14) uncertainty-aware number
+systems. These are not add-on libraries; they are *the type system of the language*.
+
+| System | Captures |
+|--------|----------|
+| Gaussian | mean ± variance; closed-form propagation |
+| Interval / affine arithmetic | guaranteed bounds; correlation tracking (affine) |
+| Fuzzy numbers | membership-graded magnitude |
+| Bayesian numbers | prior → posterior under evidence |
+| Risk-based (VaR / CVaR) | tail risk |
+| Surreal / hyperreal | infinitesimals & infinities |
+| p-adic probability | non-Archimedean / hierarchical support |
+| Imprecise probabilities | credal sets (lower/upper) |
+| Dempster–Shafer belief functions | mass over the power set; belief vs plausibility |
+
+(plus further systems converging on the target of 14.)
+
+## Why a *tower*
+
+Each system is an uncertainty *representation* with its own arithmetic; the tower is the
+ordered family of these representations, with the type system tracking which one a value
+inhabits and refusing nonsensical mixes. This is the numeric counterpart of what
+[Echo types](Echo-Types) do for *loss*: both make an aspect of uncertainty that other
+languages leave implicit into something the checker can see.
+
+## Migration to Julia
+
+Over time the tower's heavy arithmetic migrates to the Julia [compute kernel](Architecture)
+(AbstractAlgebra.jl, IntervalArithmetic.jl, differentiable inference via Zygote/Enzyme),
+while the *types* remain canonical in the Racket frontend.
+
+## Contrast
+
+R, Octave, Scilab, Mathematica and Maple can all *compute* with many of these
+representations — but they do not give them **types** that the language enforces. A
+Gaussian and an interval are just numbers/objects there; in BetLang they are distinct
+typed inhabitants of the tower. See [Formal Verification](Formal-Verification) for the
+broader comparison.
+
+Reference: `docs/number-tower.md`.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# Roadmap
+
+Tracked in `.machine_readable/6a2/STATE.a2ml`; proof obligations in `PROOF-NEEDS.md` /
+`PROOF-STATUS.md`.
+
+## Milestones
+
+| ID | Milestone | State |
+|----|-----------|-------|
+| M1 | Proof foundation — `lakefile.lean` + `proofs.yml` CI + banned-pattern gate | ✅ done (#53) |
+| M2 | Governance clean — licence, language policy, Racket tests, timeouts | ✅ done (#54) |
+| M3 | Echo types core — `Type::Echo`/`EchoR`, unify, lower, Lean `Ty.echo`/`echoR` | ✅ done (#55) |
+| M4 | Discharge `substTop_preserves_typing` axiom → **axiom-free core** | ✅ done (#40) |
+| M5 | Echo operations — `echo`/`echo_output`/`echo_map`/`echo_duplicate`/`echo_to_residue` | ✅ done, type-level (#56) |
+| M6 | `sample_echo` probabilistic bridge (type-level) / `bet_echo` runtime retention | 🟡 `sample_echo` done (#56); `bet_echo` runtime deferred |
+| M7 | Julia backend Phase 2 — core language features | ⏳ active |
+
+## Open proof obligations
+
+- **TP-5** — Echo-operation typing rules + metatheory in Lean (mirror `bet-check`'s
+  functor/comonad surface; re-establish Progress/Preservation over the echo terms).
+- SEM-1 — continuous measure-theoretic denotation.
+- STAT-1 / STAT-2 — max-entropy of uniform ternary = log₂3; SLLN for bet sample means.
+- ABI-1…5 — FFI boundary safety (Idris2).
+- CONC-1 — parallel bet-execution model (TLA+).
+
+## Next engineering advances
+
+1. **Harden `bet-check`** — add an occurs check to `unify`; replace the shared-variable
+   pseudo-polymorphism with real type schemes (generalise/instantiate at let-boundaries).
+   *(This is the immediate next work item.)*
+2. **`bet_echo` runtime** — give the branch-collapse residue a runtime representation so
+   Echo moves from ghost/type-level to operational.
+3. **TP-5 in Lean** — mechanise the echo operations' metatheory.
+4. **Julia backend Phase 2** — migrate the [number tower](Number-Tower) compute path.
+5. **`bet-wasm`** — fix the pre-existing `E0308` match-arm mismatch; unpause the WASM backend.
+
+## Known issues
+
+- `bet-wasm` E0308: pre-existing WASM backend breakage (not caused by the echo work).
+- `estate-standardization-20260607` branch is fully merged into `main` and should be
+  deleted (owner UI action — git-proxy blocks branch deletion from CI environments).

--- a/wiki/Ternary-Semantics.md
+++ b/wiki/Ternary-Semantics.md
@@ -1,0 +1,50 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# The `bet` Primitive & Ternary Semantics
+
+## The forms
+
+| Form | Meaning |
+|------|---------|
+| `(bet A B C)` | primitive stochastic choice — uniform over three branches |
+| `(bet/weighted '(A w1) '(B w2) '(C w3))` | non-uniform probabilities |
+| `(bet/conditional pred A B C)` | predicate-driven selection |
+| `(bet/lazy thunk-a thunk-b thunk-c)` | only the selected thunk is invoked |
+| `(bet-with-seed seed thunk)` | deterministic seed for reproducibility |
+
+## Laziness is load-bearing
+
+Only the **chosen** branch is evaluated. This is not an optimisation detail — it is what
+lets `bet` range over **symbolic and infinite structures** without forcing them, and it
+is the property the Rust checker and the Lean calculus must both respect. In `bet-check`,
+all three branches must *type-unify* (they share a result type) even though only one is
+*evaluated*; in Lean, the `bet e₁ e₂ e₃` step relation reduces to one branch while typing
+demands all three share a type.
+
+## Two distinct notions of "three-valued"
+
+BetLang is careful to separate:
+
+1. **Ternary logic** — Kleene-style truth values `{true, unknown, false}` (the `Ternary`
+   type). This is *logical* three-valuedness: `unknown` is a genuine truth value with its
+   own conjunction/disjunction/negation tables.
+2. **Ternary probabilistic belief** — a *distribution* over three outcomes. This is
+   *epistemic* three-valuedness: a measure, not a truth value.
+
+Conflating these is a category error. `Ternary` (Kleene) lives in the type system as a
+primitive type; probabilistic belief lives in [the number tower](Number-Tower) and the
+`Dist T` former. The distinction is formalised in `docs/ternary-semantics.md`.
+
+## Why three (not two)
+
+Per ADR-001: real-world decisions are rarely yes/no; the musical **ternary form (A–B–A)**
+gives compositional structure; and **Dutch-book** semantics need at least three outcomes
+to express the coherence constraints BetLang exists to enforce.
+
+## Composition
+
+Bets compose like algebraic objects — chaining, mapping, folding, higher-order
+composition. A `bet` is a first-class value, so `(bet (bet a b c) x y)` (nested/entangled
+choice) is ordinary. This compositionality is what makes BetLang a *metalanguage* for
+uncertainty rather than a fixed simulation script. The collapse a `bet` performs is also
+the canonical [Echo](Echo-Types) introduction site.

--- a/wiki/Type-System.md
+++ b/wiki/Type-System.md
@@ -1,0 +1,52 @@
+<!-- SPDX-License-Identifier: MPL-2.0 -->
+<!-- SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath) -->
+# Type System
+
+BetLang's type checker lives in the Rust crate `compiler/bet-check` (with core type
+definitions in `bet-core`). It is a **Hindley–Milner-style** bidirectional checker with
+unification, extended with the domain-specific formers that make BetLang what it is.
+
+## Core types
+
+`Unit`, `Bool`, `Ternary` (Kleene), `Int`, `Float`, `String`, `Bytes`, plus the compound
+formers `Fun`, `Dist`, `List`, `Map`, `Set`, `Tuple`, `Option`, `Result`, and the
+structured-loss formers **`Echo`** and **`EchoR`** (see [Echo Types](Echo-Types)).
+
+## Key typing rules
+
+- `bet { A B C }` — all three branches must unify to one type (only one is evaluated; see
+  [Ternary Semantics](Ternary-Semantics)).
+- `sample(dist)` — `Dist T → T`.
+- `observe(dist, value)` — `Dist T` and `T`.
+- `infer(method, model)` — model returns `Dist T`, result is `Dist T`.
+- The **echo operations** — `echo`, `echo_output`, `echo_map`, `echo_duplicate`,
+  `echo_to_residue`, `sample_echo` — are polymorphic builtins (see [Echo Types](Echo-Types)).
+
+## Unification and the distinctness invariant
+
+`unify` is structural and recurses through every former. The one rule that carries the
+language's identity: **`Echo T` unifies only with `Echo T'` (iff `T` ~ `T'`), never with
+the bare carrier `T`, and never with `EchoR T`.** `unify(Echo T, T)` *fails by design* —
+that failure is the entire point of "retained loss". Distinctness is enforced both at the
+former level and *through the operations* (e.g. `echo_output` applied to a bare `T` is
+rejected).
+
+## Polymorphism
+
+Echo operations are instantiated with a **fresh** type variable at every use site, so a
+single operation can be applied at many carrier types in one scope. (This is genuine
+generalisation; the legacy `to_string` builtin uses a weaker shared-variable
+approximation — replacing that with proper type schemes, and adding an occurs check to
+`unify`, is tracked next; see [Roadmap](Roadmap).)
+
+## Relationship to the other layers
+
+The Rust checker is **tooling, not semantics** (see [Architecture](Architecture)). The
+authoritative semantics are Racket's; the soundness guarantees are Lean's
+([Formal Verification](Formal-Verification)). The checker's job is fast, helpful static
+feedback consistent with both.
+
+## Source
+
+- `compiler/bet-core/src/types.rs` — the `Type` enum
+- `compiler/bet-check/src/lib.rs` — `CheckEnv`, `unify`, `resolve`, `check_expr`, `echo_builtin_type`, tests


### PR DESCRIPTION
## betlang reference-pass (estate reconciliation + hygiene) — increment 1

Part of the estate-wide reconciliation/hygiene checkpoint, with **betlang as the reference repo**.

### Branch reconciliation → one clean `main`
- `estate-standardization-20260607` is **fully merged into `main`** (`main..branch` is empty; the branch tip is the merge-base). Nothing unmerged to lose.
- Deleting it is **blocked in this environment** (git proxy returns `HTTP 403` on `push --delete`; no MCP delete-branch tool). → recorded as an **owner UI action**. After it's gone, `main` is the sole branch.

### Metadata currency (`.machine_readable/6a2/`)
- **STATE.a2ml**: reflects PR #56 — echo operations are now *typed* (the functor/comonad surface: `echo`, `echo_output`, `echo_map`, `echo_duplicate`, `echo_to_residue`, `sample_echo`). M5/M6 marked done (type-level); stale "echo operations deferred" blocker removed; next-actions refreshed (harden checker, TP-5, `bet_echo` runtime); maintenance notes 38 bet-check tests.
- **META.a2ml / ECOSYSTEM.a2ml**: drop the standards-**banned** `PMPL-1.0` token in descriptive metadata → `Palimpsest License (SPDX: MPL-2.0)`. (betlang's actual SPDX headers + root `LICENSE` were already correct MPL-2.0.)

### ⚠️ Flagged for the owner (cannot verify from here — out of MCP scope)
`Causals.jl` and `BowtieRisk.jl` both ship `LICENSES/PMPL-1.0-or-later.txt` (the *banned* identifier) while declaring MPL-2.0 canonical. Two freshly-templated repos with the identical artifact strongly implies **`rsr-template-repo` still ships the banned license file** — please check the template + `standards`.

### Still to come on this branch (betlang reference pass)
CI-health-at-root verification, issues for tracked proof/tech-debt, `bot_directives/` (greenfield format — needs a schema decision), and the repo wiki (currently none).

https://claude.ai/code/session_01QGi8GND5yNWgDyfReVEPYs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGi8GND5yNWgDyfReVEPYs)_